### PR TITLE
Create ECR client and helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This is a repository for useful methods and circe decoders. These can be used wh
 * AWS Decoders - Circe decoders for working with the above classes which are used by the event decoder method. These are needed because circe won't auto decode case classes.
 * SQS Utils - There is a send and a delete method for sqs messages.
 * SES Utils - There is a send email method.
+* ECR Utils - There is scan image method
 
 There are also clients for AWS services. These are configured with an http client, the region and an endpoint configurable in an aplication.conf file. There are:
 * An SQS Client
 * An S3 Client
 * An SES Client
+* An ECR client
 
 There may be other shared code we can put in here as time goes on.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a repository for useful methods and circe decoders. These can be used wh
 * AWS Decoders - Circe decoders for working with the above classes which are used by the event decoder method. These are needed because circe won't auto decode case classes.
 * SQS Utils - There is a send and a delete method for sqs messages.
 * SES Utils - There is a send email method.
-* ECR Utils - There is scan image method
+* ECR Utils - There are methods to list repositories, describe images and start an image scan.
 
 There are also clients for AWS services. These are configured with an http client, the region and an endpoint configurable in an aplication.conf file. There are:
 * An SQS Client

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 import Dependencies._
 import sbt.url
 
@@ -42,6 +43,7 @@ lazy val root = (project in file("."))
       mockito % Test,
       lambdaJavaCore,
       lambdaJavaEvents,
+      ecrSdk,
       ses,
       s3Sdk,
       sqsSdk,
@@ -49,6 +51,8 @@ lazy val root = (project in file("."))
       circeCore,
       circeGeneric,
       circeParser,
+      monix,
+      monixEval
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,12 @@ object Dependencies {
   lazy val s3Sdk = "software.amazon.awssdk" % "s3" % "2.13.18"
   lazy val ses = "software.amazon.awssdk" % "ses" % "2.15.2"
   lazy val sqsSdk = "software.amazon.awssdk" % "sqs" % "2.13.15"
+  lazy val ecrSdk = "software.amazon.awssdk" % "ecr" % "2.13.15"
   lazy val typesafe = "com.typesafe" % "config" % "1.4.0"
   lazy val circeCore = "io.circe" %% "circe-core" % "0.13.0"
   lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.13.0"
+  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "2.2.0"
+  lazy val monix = "io.monix" %% "monix" % "3.2.2"
+  lazy val monixEval = "io.monix" %% "monix-eval" % "3.2.2"
 }

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.ecr.{EcrAsyncClient, EcrClient}
+import software.amazon.awssdk.services.ecr.EcrAsyncClient
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ses.SesClient
 import software.amazon.awssdk.services.sqs.SqsClient
@@ -50,6 +50,4 @@ object Clients {
       .httpClient(httpClient)
       .build
   }
-
-
 }

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
@@ -4,7 +4,9 @@ import java.net.URI
 
 import com.typesafe.config.{Config, ConfigFactory}
 import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ecr.{EcrAsyncClient, EcrClient}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ses.SesClient
 import software.amazon.awssdk.services.sqs.SqsClient
@@ -38,6 +40,15 @@ object Clients {
       .endpointOverride(URI.create(configFactory.getString("ses.endpoint")))
       .httpClient(httpClient)
       .build()
+  }
+
+  def ecr: EcrAsyncClient = {
+    val httpClient = NettyNioAsyncHttpClient.builder.build
+    EcrAsyncClient.builder
+      .region(Region.EU_WEST_2)
+      .endpointOverride(URI.create(configFactory.getString("ecr.endpoint")))
+      .httpClient(httpClient)
+      .build
   }
 
 

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
@@ -19,14 +19,12 @@ class ECRUtils(client: EcrAsyncClient) {
 
   def describeImages(repositoryName: String): IO[DescribeImagesResponse] = {
     val request = DescribeImagesRequest.builder().repositoryName(repositoryName).build()
-
     IO(client.describeImages(request)).futureLift
   }
 
   def listRepositories(): IO[DescribeRepositoriesResponse] = {
     IO(client.describeRepositories()).futureLift
   }
-
 }
 
 object ECRUtils {

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
@@ -1,10 +1,10 @@
 package uk.gov.nationalarchives.aws.utils
 
-import software.amazon.awssdk.services.ecr.{EcrAsyncClient, EcrClient}
-import software.amazon.awssdk.services.ecr.model.{BatchGetImageRequest, DescribeImagesRequest, DescribeImagesResponse, DescribeRepositoriesResponse, ImageIdentifier, StartImageScanRequest, StartImageScanResponse}
-import uk.gov.nationalarchives.aws.utils.ECRUtils.EcrImage
 import cats.effect.IO
 import monix.catnap.syntax._
+import software.amazon.awssdk.services.ecr.EcrAsyncClient
+import software.amazon.awssdk.services.ecr.model._
+import uk.gov.nationalarchives.aws.utils.ECRUtils.EcrImage
 
 class ECRUtils(client: EcrAsyncClient) {
 

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
@@ -1,0 +1,36 @@
+package uk.gov.nationalarchives.aws.utils
+
+import software.amazon.awssdk.services.ecr.{EcrAsyncClient, EcrClient}
+import software.amazon.awssdk.services.ecr.model.{BatchGetImageRequest, DescribeImagesRequest, DescribeImagesResponse, DescribeRepositoriesResponse, ImageIdentifier, StartImageScanRequest, StartImageScanResponse}
+import uk.gov.nationalarchives.aws.utils.ECRUtils.EcrImage
+import cats.effect.IO
+import monix.catnap.syntax._
+
+class ECRUtils(client: EcrAsyncClient) {
+
+  def startImageScan(ecrImage: EcrImage): IO[StartImageScanResponse] = {
+    val imageIdentifier = ImageIdentifier.builder.imageDigest(ecrImage.imageDigest).imageTag(ecrImage.imageTag).build
+    val request = StartImageScanRequest.builder
+      .imageId(imageIdentifier)
+      .repositoryName(ecrImage.repositoryMame)
+      .build
+    IO(client.startImageScan(request)).futureLift
+  }
+
+  def describeImages(repositoryName: String): IO[DescribeImagesResponse] = {
+    val request = DescribeImagesRequest.builder().repositoryName(repositoryName).build()
+
+    IO(client.describeImages(request)).futureLift
+  }
+
+  def listRepositories(): IO[DescribeRepositoriesResponse] = {
+    IO(client.describeRepositories()).futureLift
+  }
+
+}
+
+object ECRUtils {
+  case class EcrImage(imageDigest: String, imageTag: String, repositoryMame: String)
+
+  def apply(client: EcrAsyncClient): ECRUtils = new ECRUtils(client)
+}

--- a/src/test/scala/uk/gov/nationalarchives/aws/utils/ECRUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aws/utils/ECRUtilsTest.scala
@@ -1,0 +1,54 @@
+package uk.gov.nationalarchives.aws.utils
+
+import java.util.concurrent.CompletableFuture
+
+import org.mockito.{ArgumentCaptor, Mockito, MockitoSugar}
+import org.scalatest.flatspec.AnyFlatSpec
+import software.amazon.awssdk.services.ecr.{EcrAsyncClient, EcrClient}
+import software.amazon.awssdk.services.ecr.model.{DescribeImagesRequest, DescribeImagesResponse, DescribeRepositoriesResponse, StartImageScanRequest, StartImageScanResponse}
+import org.scalatest.matchers.should.Matchers._
+import uk.gov.nationalarchives.aws.utils.ECRUtils.EcrImage
+
+class ECRUtilsTest extends AnyFlatSpec with MockitoSugar {
+
+  "The startImageScan method" should "be called with the correct parameters" in {
+    val mockResponse = CompletableFuture.completedFuture(StartImageScanResponse.builder.build)
+    val ecrClient = Mockito.mock(classOf[EcrAsyncClient])
+    val ecrUtils = ECRUtils(ecrClient)
+    val argumentCaptor: ArgumentCaptor[StartImageScanRequest] = ArgumentCaptor.forClass(classOf[StartImageScanRequest])
+
+    doAnswer(() => mockResponse).when(ecrClient).startImageScan(argumentCaptor.capture())
+
+    ecrUtils.startImageScan(EcrImage("digest", "tag", "repository")).unsafeRunSync()
+
+    argumentCaptor.getValue.imageId.imageDigest should be("digest")
+    argumentCaptor.getValue.imageId.imageTag should be("tag")
+    argumentCaptor.getValue.repositoryName should be("repository")
+  }
+
+  "The getImages method" should "be called with the correct parameters" in {
+    val mockResponse = CompletableFuture.completedFuture(DescribeImagesResponse.builder.build)
+    val ecrClient = Mockito.mock(classOf[EcrAsyncClient])
+    val ecrUtils = ECRUtils(ecrClient)
+    val argumentCaptor: ArgumentCaptor[DescribeImagesRequest] = ArgumentCaptor.forClass(classOf[DescribeImagesRequest])
+
+    doAnswer(() => mockResponse).when(ecrClient).describeImages(argumentCaptor.capture())
+
+    ecrUtils.describeImages("repository").unsafeRunSync()
+
+    argumentCaptor.getValue.repositoryName() should be("repository")
+  }
+
+  "The listRepositories method" should "be called with the correct parameters" in {
+    val mockResponse = CompletableFuture.completedFuture(DescribeRepositoriesResponse.builder.build)
+    val ecrClient = Mockito.mock(classOf[EcrAsyncClient])
+    val ecrUtils = ECRUtils(ecrClient)
+
+    doAnswer(() => mockResponse).when(ecrClient).describeRepositories()
+
+    ecrUtils.listRepositories().unsafeRunSync()
+
+    verify(ecrClient).describeRepositories()
+
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1"
+version in ThisBuild := "0.0.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"
+version in ThisBuild := "0.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.0.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2-SNAPSHOT"
+version in ThisBuild := "0.1.5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.5-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
The ECR client is now returning a cats.effect IO wrapper around the response and is using the AWS async client. The lambda consuming this is using cats-effect so this is fine but we may change this in the future.
