### PR TITLE
Use correct param for sfn publish failure

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
@@ -65,7 +65,7 @@ object Clients {
     val httpClient = NettyNioAsyncHttpClient.builder.build
     SfnAsyncClient.builder
       .region(Region.EU_WEST_2)
-      .endpointOverride(URI.create(configFactory.getString("sfn.endpoint")))
+      .endpointOverride(URI.create(configFactory.getString("stepFunction.endpoint")))
       .httpClient(httpClient)
       .build
   }

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
@@ -61,11 +61,11 @@ object Clients {
       .build
   }
 
-  def sfnAsyncClient: SfnAsyncClient = {
+  def sfnAsyncClient(endpointPath: String): SfnAsyncClient = {
     val httpClient = NettyNioAsyncHttpClient.builder.build
     SfnAsyncClient.builder
       .region(Region.EU_WEST_2)
-      .endpointOverride(URI.create(configFactory.getString("stepFunction.endpoint")))
+      .endpointOverride(URI.create(endpointPath))
       .httpClient(httpClient)
       .build
   }

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtils.scala
@@ -17,10 +17,10 @@ class StepFunctionUtils(client: SfnAsyncClient) {
     IO(client.sendTaskSuccess(request)).futureLift
   }
 
-  def sendTaskFailureRequest(taskToken: String, error: String): IO[SendTaskFailureResponse] = {
+  def sendTaskFailureRequest(taskToken: String, cause: String): IO[SendTaskFailureResponse] = {
     val request = SendTaskFailureRequest.builder
       .taskToken(taskToken)
-      .error(error)
+      .cause(cause)
       .build
 
     IO(client.sendTaskFailure(request)).futureLift

--- a/src/test/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtilsTest.scala
@@ -16,7 +16,7 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
 
   private val taskToken: String = "taskToken"
   private val outputJson = Json.fromString("outputJson")
-  private val errorMessage = "some error occurred"
+  private val causeMessage = "some error occurred"
 
   "the sendTaskSuccessRequest method" should "be called with the correct parameters" in {
     val stepFunctionClient = Mockito.mock(classOf[SfnAsyncClient])
@@ -53,11 +53,11 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
 
     when(stepFunctionClient.sendTaskFailure(argumentCaptor.capture())).thenReturn(CompletableFuture.completedFuture(response))
 
-    stepFunctionUtils.sendTaskFailureRequest(taskToken, errorMessage).unsafeRunSync()
+    stepFunctionUtils.sendTaskFailureRequest(taskToken, causeMessage).unsafeRunSync()
 
     val request: SendTaskFailureRequest = argumentCaptor.getValue
     request.taskToken should equal("taskToken")
-    request.error should equal(errorMessage)
+    request.cause should equal(causeMessage)
   }
 
   "The sendTaskFailureRequest method" should "return an error if the request fails" in {
@@ -66,7 +66,7 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
       .thenReturn(failedFuture(new RuntimeException("Task failure request failed")))
 
     val stepFunctionUtils = StepFunctionUtils(stepFunctionClient)
-    val response = stepFunctionUtils.sendTaskFailureRequest(taskToken, errorMessage).attempt.unsafeRunSync()
+    val response = stepFunctionUtils.sendTaskFailureRequest(taskToken, causeMessage).attempt.unsafeRunSync()
     response.left.value.getMessage should equal("Task failure request failed")
   }
 }


### PR DESCRIPTION
Accord to the AWS documentation the "cause" field should provide detailed information about the failure: https://docs.aws.amazon.com/step-functions/latest/apireference/API_SendTaskFailure.html

The error field should be the error code