### PR TITLE
Require library clients to pass endpoint when creating ECR client

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/Clients.scala
@@ -52,11 +52,11 @@ object Clients {
       .build()
   }
 
-  def ecr: EcrAsyncClient = {
+  def ecr(endpoint: URI): EcrAsyncClient = {
     val httpClient = NettyNioAsyncHttpClient.builder.build
     EcrAsyncClient.builder
       .region(Region.EU_WEST_2)
-      .endpointOverride(URI.create(configFactory.getString("ecr.endpoint")))
+      .endpointOverride(endpoint)
       .httpClient(httpClient)
       .build
   }


### PR DESCRIPTION
This reduces coupling between this library and how the library clients are storing their config.

I'm just updating this one because I'm about to add another method on the ECR client.