### PR TITLE
Add wrapper method for fetching ECR scan findings

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/ECRUtils.scala
@@ -17,6 +17,15 @@ class ECRUtils(client: EcrAsyncClient) {
     IO(client.startImageScan(request)).futureLift
   }
 
+  def imageScanFindings(repositoryName: String, imageDigest: String): IO[DescribeImageScanFindingsResponse] = {
+    val request = DescribeImageScanFindingsRequest.builder()
+      .repositoryName(repositoryName)
+      .imageId(ImageIdentifier.builder().imageDigest(imageDigest).build())
+      .build()
+
+    IO(client.describeImageScanFindings(request)).futureLift
+  }
+
   def describeImages(repositoryName: String): IO[DescribeImagesResponse] = {
     val request = DescribeImagesRequest.builder().repositoryName(repositoryName).build()
     IO(client.describeImages(request)).futureLift

--- a/src/test/scala/uk/gov/nationalarchives/aws/utils/ECRUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aws/utils/ECRUtilsTest.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture
 import org.mockito.{ArgumentCaptor, Mockito, MockitoSugar}
 import org.scalatest.flatspec.AnyFlatSpec
 import software.amazon.awssdk.services.ecr.{EcrAsyncClient, EcrClient}
-import software.amazon.awssdk.services.ecr.model.{DescribeImagesRequest, DescribeImagesResponse, DescribeRepositoriesResponse, StartImageScanRequest, StartImageScanResponse}
+import software.amazon.awssdk.services.ecr.model.{DescribeImageScanFindingsRequest, DescribeImageScanFindingsResponse, DescribeImagesRequest, DescribeImagesResponse, DescribeRepositoriesResponse, ImageScanFinding, ImageScanFindings, StartImageScanRequest, StartImageScanResponse}
 import org.scalatest.matchers.should.Matchers._
 import uk.gov.nationalarchives.aws.utils.ECRUtils.EcrImage
 
@@ -49,6 +49,40 @@ class ECRUtilsTest extends AnyFlatSpec with MockitoSugar {
     ecrUtils.listRepositories().unsafeRunSync()
 
     verify(ecrClient).describeRepositories()
+  }
 
+  "imageScanFindings" should "get images details from the AWS client" in {
+    val repoName = "some-repository-name"
+    val sha256Digest = "some-sha256-digest"
+    val vulnerability1 = "CVE-2021-123456"
+    val vulnerability2 = "CVE-2021-234567"
+
+    val findings = DescribeImageScanFindingsResponse.builder
+      .imageScanFindings(ImageScanFindings.builder()
+        .findings(
+          ImageScanFinding.builder().name(vulnerability1).build(),
+          ImageScanFinding.builder().name(vulnerability2).build()
+        )
+        .build()
+      )
+      .build()
+    val response = CompletableFuture.completedFuture(findings)
+    val ecrClient = Mockito.mock(classOf[EcrAsyncClient])
+    val ecrUtils = ECRUtils(ecrClient)
+
+    val argumentCaptor: ArgumentCaptor[DescribeImageScanFindingsRequest] =
+      ArgumentCaptor.forClass(classOf[DescribeImageScanFindingsRequest])
+
+    doAnswer(() => response).when(ecrClient).describeImageScanFindings(argumentCaptor.capture())
+
+    val scanFindings = ecrUtils.imageScanFindings(repoName, sha256Digest).unsafeRunSync()
+
+    val actualRequest = argumentCaptor.getValue
+    actualRequest.repositoryName should be(repoName)
+    actualRequest.imageId.imageDigest should be(sha256Digest)
+
+    scanFindings.imageScanFindings.findings.size should be(2)
+    scanFindings.imageScanFindings.findings.get(0).name should be(vulnerability1)
+    scanFindings.imageScanFindings.findings.get(1).name should be(vulnerability2)
   }
 }


### PR DESCRIPTION
Fetch the security scan findings for an image in the Elastic Container Registry, given its repository name and SHA-256 digest.

This is needed by tdr-notifications, so that we can filter scan alerts by the details of the findings.