### PR TITLE
Remove Jenkins step which publishes Jenkins job as version number

### DIFF
--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -1,6 +1,5 @@
 library("tdr-jenkinslib")
 
-def versionTag = "v${env.BUILD_NUMBER}"
 def repo = "tdr-aws-utils"
 
 pipeline {
@@ -35,15 +34,7 @@ pipeline {
         expression { env.BRANCH_NAME == "master"}
       }
       stages {
-        stage('Tag Release') {
-          steps {
-            sh "git tag ${versionTag}"
-            sshagent(['github-jenkins']) {
-              sh("git push origin ${versionTag}")
-            }
-          }
-        }
-        stage('Deploy to integration') {
+        stage('Publish library') {
           steps {
             build(
               job: "TDR AWS Utils", wait: false)


### PR DESCRIPTION
This version number wasn't needed, because this is a library rather than a deployable service. The library's version number is still being published as a git tag by the deployment job. This commit just removes the incorrect second tag.