### PR TITLE
Add method which resets SQS message visibility

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/SQSUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/SQSUtils.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.aws.utils
 
 import software.amazon.awssdk.services.sqs.SqsClient
-import software.amazon.awssdk.services.sqs.model.{DeleteMessageRequest, DeleteMessageResponse, SendMessageRequest, SendMessageResponse}
+import software.amazon.awssdk.services.sqs.model._
 
 class SQSUtils(sqsClient: SqsClient) {
 
@@ -19,6 +19,16 @@ class SQSUtils(sqsClient: SqsClient) {
         .queueUrl(queueUrl)
         .receiptHandle(receiptHandle)
         .build())
+  }
+
+  def makeMessageVisible(queueUrl: String, receiptHandle: String): ChangeMessageVisibilityResponse = {
+    sqsClient.changeMessageVisibility(
+      ChangeMessageVisibilityRequest.builder
+        .queueUrl(queueUrl)
+        .receiptHandle(receiptHandle)
+        .visibilityTimeout(0)
+        .build
+    )
   }
 }
 

--- a/src/test/scala/uk/gov/nationalarchives/aws/utils/SQSUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aws/utils/SQSUtilsTest.scala
@@ -2,9 +2,9 @@ package uk.gov.nationalarchives.aws.utils
 
 import org.mockito.{ArgumentCaptor, Mockito, MockitoSugar}
 import org.scalatest.flatspec.AnyFlatSpec
-import software.amazon.awssdk.services.sqs.SqsClient
-import software.amazon.awssdk.services.sqs.model.{DeleteMessageRequest, DeleteMessageResponse, SendMessageRequest, SendMessageResponse}
 import org.scalatest.matchers.should.Matchers._
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model._
 
 class SQSUtilsTest extends AnyFlatSpec with MockitoSugar {
 
@@ -35,5 +35,22 @@ class SQSUtilsTest extends AnyFlatSpec with MockitoSugar {
     val request: DeleteMessageRequest = argumentCaptor.getValue
     request.queueUrl should equal("testurl")
     request.receiptHandle() should equal("testreceipthandle")
+  }
+
+  "The makeMessageVisible method" should "set the visibility to zero" in {
+    val sqsClient = Mockito.mock(classOf[SqsClient])
+    val sqsUtils = SQSUtils(sqsClient)
+    val argumentCaptor: ArgumentCaptor[ChangeMessageVisibilityRequest] =
+      ArgumentCaptor.forClass(classOf[ChangeMessageVisibilityRequest])
+    val mockResponse = ChangeMessageVisibilityResponse.builder.build
+
+    doAnswer(() => mockResponse).when(sqsClient).changeMessageVisibility(argumentCaptor.capture())
+
+    sqsUtils.makeMessageVisible("testurl", "testreceipthandle")
+
+    val request: ChangeMessageVisibilityRequest = argumentCaptor.getValue
+    request.queueUrl should equal("testurl")
+    request.receiptHandle should equal("testreceipthandle")
+    request.visibilityTimeout should equal(0)
   }
 }


### PR DESCRIPTION
This is useful when an SQS message processor encounters an error, so the message needs to be retried.

If the message visibility is not reset, the message will only become visible when its visibility timeout expires. If the processor calls this new method, the message will be available for retry immediately.