### PR TITLE
Add send heartbeat task function.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 import Dependencies._
 import sbt.url
 
-ThisBuild / scalaVersion     := "2.13.2"
+ThisBuild / scalaVersion     := "2.13.6"
 ThisBuild / version          := (version in ThisBuild).value
 ThisBuild / organization     := "uk.gov.nationalarchives.aws.utils"
 

--- a/src/main/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtils.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import io.circe.Json
 import monix.catnap.syntax.SyntaxForLiftFuture
 import software.amazon.awssdk.services.sfn.SfnAsyncClient
-import software.amazon.awssdk.services.sfn.model.{SendTaskFailureRequest, SendTaskFailureResponse, SendTaskSuccessRequest, SendTaskSuccessResponse}
+import software.amazon.awssdk.services.sfn.model.{SendTaskFailureRequest, SendTaskFailureResponse, SendTaskHeartbeatRequest, SendTaskHeartbeatResponse, SendTaskSuccessRequest, SendTaskSuccessResponse}
 
 class StepFunctionUtils(client: SfnAsyncClient) {
 
@@ -24,6 +24,13 @@ class StepFunctionUtils(client: SfnAsyncClient) {
       .build
 
     IO(client.sendTaskFailure(request)).futureLift
+  }
+
+  def sendTaskHeartbeat(taskToken: String): IO[SendTaskHeartbeatResponse] = {
+    val request = SendTaskHeartbeatRequest.builder
+      .taskToken(taskToken)
+      .build()
+    IO(client.sendTaskHeartbeat(request)).futureLift
   }
 }
 

--- a/src/test/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtilsTest.scala
@@ -1,7 +1,6 @@
 package uk.gov.nationalarchives.aws.utils
 
 import java.util.concurrent.CompletableFuture
-
 import io.circe.Json
 import org.mockito.ArgumentMatchers.any
 import org.mockito.{ArgumentCaptor, Mockito, MockitoSugar}
@@ -9,7 +8,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import software.amazon.awssdk.services.sfn.SfnAsyncClient
-import software.amazon.awssdk.services.sfn.model.{SendTaskFailureRequest, SendTaskFailureResponse, SendTaskSuccessRequest, SendTaskSuccessResponse}
+import software.amazon.awssdk.services.sfn.model.{SendTaskFailureRequest, SendTaskFailureResponse, SendTaskHeartbeatRequest, SendTaskHeartbeatResponse, SendTaskSuccessRequest, SendTaskSuccessResponse}
 import uk.gov.nationalarchives.aws.utils.TestUtils.failedFuture
 
 class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues {
@@ -68,5 +67,30 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
     val stepFunctionUtils = StepFunctionUtils(stepFunctionClient)
     val response = stepFunctionUtils.sendTaskFailureRequest(taskToken, causeMessage).attempt.unsafeRunSync()
     response.left.value.getMessage should equal("Task failure request failed")
+  }
+
+  "the sendTaskHeartbeat method" should "be called with the correct parameters" in {
+    val stepFunctionClient = Mockito.mock(classOf[SfnAsyncClient])
+    val stepFunctionUtils = StepFunctionUtils(stepFunctionClient)
+
+    val argumentCaptor: ArgumentCaptor[SendTaskHeartbeatRequest] = ArgumentCaptor.forClass(classOf[SendTaskHeartbeatRequest])
+    val response = SendTaskHeartbeatResponse.builder.build
+
+    when(stepFunctionClient.sendTaskHeartbeat(argumentCaptor.capture())).thenReturn(CompletableFuture.completedFuture(response))
+
+    stepFunctionUtils.sendTaskHeartbeat(taskToken).unsafeRunSync()
+
+    val request: SendTaskHeartbeatRequest = argumentCaptor.getValue
+    request.taskToken should equal("taskToken")
+  }
+
+  "The sendTaskHeartbeat method" should "return an error if the request fails" in {
+    val stepFunctionClient = Mockito.mock(classOf[SfnAsyncClient])
+    when(stepFunctionClient.sendTaskHeartbeat(any[SendTaskHeartbeatRequest]))
+      .thenReturn(failedFuture(new RuntimeException("Task heartbeat request failed")))
+
+    val stepFunctionUtils = StepFunctionUtils(stepFunctionClient)
+    val response = stepFunctionUtils.sendTaskHeartbeat(taskToken).attempt.unsafeRunSync()
+    response.left.value.getMessage should equal("Task heartbeat request failed")
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aws/utils/StepFunctionUtilsTest.scala
@@ -33,7 +33,7 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
     request.output should equal(outputJson.toString())
   }
 
-  "The sendTaskSuccessRequest method" should "return an error if the request fails" in {
+  "the sendTaskSuccessRequest method" should "return an error if the request fails" in {
     val stepFunctionClient = Mockito.mock(classOf[SfnAsyncClient])
     when(stepFunctionClient.sendTaskSuccess(any[SendTaskSuccessRequest]))
       .thenReturn(failedFuture(new RuntimeException("Task success request failed")))
@@ -59,7 +59,7 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
     request.cause should equal(causeMessage)
   }
 
-  "The sendTaskFailureRequest method" should "return an error if the request fails" in {
+  "the sendTaskFailureRequest method" should "return an error if the request fails" in {
     val stepFunctionClient = Mockito.mock(classOf[SfnAsyncClient])
     when(stepFunctionClient.sendTaskFailure(any[SendTaskFailureRequest]))
       .thenReturn(failedFuture(new RuntimeException("Task failure request failed")))
@@ -84,7 +84,7 @@ class StepFunctionUtilsTest extends AnyFlatSpec with MockitoSugar with EitherVal
     request.taskToken should equal("taskToken")
   }
 
-  "The sendTaskHeartbeat method" should "return an error if the request fails" in {
+  "the sendTaskHeartbeat method" should "return an error if the request fails" in {
     val stepFunctionClient = Mockito.mock(classOf[SfnAsyncClient])
     when(stepFunctionClient.sendTaskHeartbeat(any[SendTaskHeartbeatRequest]))
       .thenReturn(failedFuture(new RuntimeException("Task heartbeat request failed")))


### PR DESCRIPTION
I've added in some tests for the function. I've also upgraded the scala version as I think we were running into this bug.
https://github.com/scala/bug/issues/12038
There was a similar error on one of the AWS classes which had a builder and only happened every second test run. It's gone away with the upgrade.
