### PR TITLE
dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 import sbt.url
 import sbtrelease.ReleaseStateTransformations._
 
-ThisBuild / scalaVersion     := "2.13.6"
+ThisBuild / scalaVersion     := "2.13.8"
 ThisBuild / version          := (ThisBuild / version ).value
 ThisBuild / organization     := "uk.gov.nationalarchives"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val awsSdkVersion = "2.17.158"
-  private val circeVersion = "0.13.0"
+  private val circeVersion = "0.14.1"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val awsSdkVersion = "2.17.158"
+  private val awsSdkVersion = "2.17.160"
   private val circeVersion = "0.13.0"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   private val circeVersion = "0.13.0"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
-  lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
+  lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.8"
   lazy val lambdaJavaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val lambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.1.0"
   lazy val s3Sdk = "software.amazon.awssdk" % "s3" % awsSdkVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   private val awsSdkVersion = "2.17.158"
   private val circeVersion = "0.13.0"
 
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.4"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
   lazy val lambdaJavaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val lambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,5 +19,5 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.2.9"
+  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.3.9"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
   lazy val lambdaJavaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-  lazy val lambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.1.0"
+  lazy val lambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.1.1"
   lazy val s3Sdk = "software.amazon.awssdk" % "s3" % awsSdkVersion
   lazy val sesSdk = "software.amazon.awssdk" % "ses" % awsSdkVersion
   lazy val sqsSdk = "software.amazon.awssdk" % "sqs" % awsSdkVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val sfnSdk = "software.amazon.awssdk" % "sfn" % awsSdkVersion
   lazy val kmsSdk = "software.amazon.awssdk" % "kms" % awsSdkVersion
   lazy val snsSdk = "software.amazon.awssdk" % "sns" % awsSdkVersion
-  lazy val typesafe = "com.typesafe" % "config" % "1.4.0"
+  lazy val typesafe = "com.typesafe" % "config" % "1.4.2"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.5.8

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
   "javax.xml.bind" % "jaxb-api" % "2.3.0",
   "com.sun.xml.bind" % "jaxb-ri" % "2.3.0",
-  "org.glassfish.jaxb" % "jaxb-runtime" % "3.0.0-M5"
+  "org.glassfish.jaxb" % "jaxb-runtime" % "3.0.2"
 )

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "javax.xml.bind" % "jaxb-api" % "2.3.0",
+  "javax.xml.bind" % "jaxb-api" % "2.3.1",
   "com.sun.xml.bind" % "jaxb-ri" % "2.3.0",
   "org.glassfish.jaxb" % "jaxb-runtime" % "3.0.0-M5"
 )

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
   "javax.xml.bind" % "jaxb-api" % "2.3.0",
-  "com.sun.xml.bind" % "jaxb-ri" % "2.3.0",
+  "com.sun.xml.bind" % "jaxb-ri" % "2.3.6",
   "org.glassfish.jaxb" % "jaxb-runtime" % "3.0.0-M5"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 resolvers += Resolver.jcenterRepo
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")


### PR DESCRIPTION
- Update aws-lambda-java-events to 3.1.1
- Update sbt-release to 1.0.15
- Update typesafe:config to 1.4.2
- Update jaxb-api to 2.3.1
- Update jaxb-runtime to 3.0.2
- Update scala-library to 2.13.8
- Update sbt to 1.5.8
- Update scalatest to 3.1.4
- Update cats-effect to 3.3.9
- Update ecr, kms, s3, ses, sfn, sns, sqs to 2.17.160
