### PR TITLE
Migrate to using GitHub Enterprise service account

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ queue_rules:
 pull_request_rules:
   - name: automatic merge for Scala Steward
     conditions:
-      - author=tna-digital-archiving-jenkins
+      - author=tna-da-bot
       - "check-success=test"
       - "check-success=security/snyk (nationalarchives)"
       - or:

--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ lazy val commonSettings = Seq(
   ),
   developers := List(
     Developer(
-      id = "tna-digital-archiving-jenkins",
+      id = "tna-da-bot",
       name = "TNA Digital Archiving",
-      email = "digitalpreservation@nationalarchives.gov.uk",
+      email = "s-GitHubDABot@nationalarchives.gov.uk",
       url = url("https://github.com/nationalarchives/tdr-aws-utils")
     )
   ),


### PR DESCRIPTION
Update the service account to the new GitHub Enterprise one.
The new ssm params come in from: https://github.com/nationalarchives/tdr-terraform-github/pull/35
 